### PR TITLE
Updates for Jupyterhub

### DIFF
--- a/notebooks-sam/Explore-data.ipynb
+++ b/notebooks-sam/Explore-data.ipynb
@@ -14,7 +14,9 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import os; os.chdir('../')"
@@ -23,12 +25,14 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'/home/maurer/github/ual/urbansim_parcel_bayarea'"
+       "'/Users/maurer/Dropbox/Git-imac/ual/urbansim_parcel_bayarea'"
       ]
      },
      "execution_count": 2,
@@ -43,7 +47,9 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -53,13 +59,15 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/maurer/anaconda3/lib/python3.6/site-packages/statsmodels/compat/pandas.py:56: FutureWarning: The pandas.core.datetools module is deprecated and will be removed in a future version. Please use the pandas.tseries module instead.\n",
+      "/Users/maurer/anaconda/lib/python3.6/site-packages/statsmodels/compat/pandas.py:56: FutureWarning: The pandas.core.datetools module is deprecated and will be removed in a future version. Please use the pandas.tseries module instead.\n",
       "  from pandas.core import datetools\n"
      ]
     }
@@ -71,8 +79,22 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Run this cell to override the standard data directory, if needed\n",
+    "orca.add_injectable('data_directory', '/home/data/')"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# Load script-based Orca registrations\n",
@@ -98,8 +120,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -133,7 +157,9 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "data": {
@@ -153,7 +179,9 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "data": {
@@ -173,7 +201,9 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "data": {
@@ -216,7 +246,9 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -235,7 +267,9 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "data": {
@@ -255,7 +289,9 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "data": {
@@ -276,7 +312,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   },
@@ -290,7 +328,9 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -370,7 +410,9 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -387,7 +429,9 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "data": {
@@ -639,7 +683,9 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "data": {
@@ -675,7 +721,9 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "data": {

--- a/notebooks-sam/Explore-data.ipynb
+++ b/notebooks-sam/Explore-data.ipynb
@@ -14,9 +14,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import os; os.chdir('../')"
@@ -25,9 +23,27 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'/home/maurer/github/ual/urbansim_parcel_bayarea'"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "os.getcwd()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -36,16 +52,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 4,
+   "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/maurer/anaconda/lib/python3.6/site-packages/statsmodels/compat/pandas.py:56: FutureWarning: The pandas.core.datetools module is deprecated and will be removed in a future version. Please use the pandas.tseries module instead.\n",
+      "/home/maurer/anaconda3/lib/python3.6/site-packages/statsmodels/compat/pandas.py:56: FutureWarning: The pandas.core.datetools module is deprecated and will be removed in a future version. Please use the pandas.tseries module instead.\n",
       "  from pandas.core import datetools\n"
      ]
     }
@@ -57,10 +71,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 5,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Load script-based Orca registrations\n",
@@ -87,9 +99,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -123,9 +133,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -145,9 +153,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -167,9 +173,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -212,9 +216,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -233,9 +235,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -255,9 +255,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -278,9 +276,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   },
@@ -294,9 +290,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -376,9 +370,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -395,9 +387,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -649,9 +639,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -687,9 +675,7 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {

--- a/scripts/datasources.py
+++ b/scripts/datasources.py
@@ -8,18 +8,26 @@ import zipfile
 # data documentation: https://berkeley.app.box.com/notes/282712547032
 
 
+# Set data directory
+
+d = 'data/'
+
+if 'data_directory' in orca.list_injectables():
+    d = orca.get_injectable('data_directory')
+
+
 ############################################################
 
 # Tables from MTC Bay Area UrbanSim
 
 @orca.table(cache=True)
 def parcels():
-    df = pd.read_hdf('data/bayarea_ual.h5', 'parcels')
+    df = pd.read_hdf(d + 'bayarea_ual.h5', 'parcels')
     return df
 
 @orca.table(cache=True)
 def buildings():
-    df = pd.read_hdf('data/bayarea_ual.h5', 'buildings')
+    df = pd.read_hdf(d + 'bayarea_ual.h5', 'buildings')
     return df
 
 
@@ -29,19 +37,19 @@ def buildings():
 
 @orca.table(cache=True)
 def units():
-    z = zipfile.ZipFile('data/units_w_tenure.zip')
+    z = zipfile.ZipFile(d + 'units_w_tenure.zip')
     df = pd.read_csv(z.open('units_w_tenure.csv'))
     return df
 
 @orca.table(cache=True)
 def households():
-    z = zipfile.ZipFile('data/synthpop_w_units.zip')
+    z = zipfile.ZipFile(d + 'synthpop_w_units.zip')
     df = pd.read_csv(z.open('households_w_units.csv'))
     return df
 
 @orca.table(cache=True)
 def persons():
-    z = zipfile.ZipFile('data/synthpop_w_units.zip')
+    z = zipfile.ZipFile(d + 'synthpop_w_units.zip')
     df = pd.read_csv(z.open('sfbay_persons_2018_04_16.csv'))
     return df
 


### PR DESCRIPTION
This PR includes a couple of updates to the shared scripts, so we can run them in Jupyterhub:

1. Adds `__init__.py` for the scripts directory (this wasn't causing a problem on my machine, but in Jupyterhub on the Rome server I wasn't able to import the contents otherwise).

2. Adds flexible specification of the data directory, through changes to datasources.py and to the [Explore-data](https://github.com/ual/urbansim_parcel_bayarea/blob/sam/notebooks-sam/Explore-data.ipynb) notebook. (Haven't tested this on Rome because I started having trouble launching the Jupyerhub process, but it works as intended locally.)