### PR TITLE
Bug fix in data import; notebook with probabilities demo

### DIFF
--- a/configs/modelmanager_configs.yaml
+++ b/configs/modelmanager_configs.yaml
@@ -218,13 +218,15 @@ model_one:
 large-mnl-test:
     alt_filters: null
     alt_sample_size: 10
-    alternatives: buildings
-    choice_column: building_id
+    alternatives:
+    - units
+    - buildings
+    choice_column: unit_id
     chooser_filters:
     - household_id % 1000 < 1
     choosers: households
     fitted_parameters:
-    - 0.00045990926356891706
+    - 1.805049467592521e-05
     model_expression: res_price_per_sqft - 1
     name: large-mnl-test
     out_alt_filters: null
@@ -239,11 +241,11 @@ large-mnl-test:
         \     Maximum Likelihood   Df Model:                       \nDate:       \
         \                       Pseudo R-squ.:                  \nTime:          \
         \                    Pseudo R-bar-squ.:              \nAIC:              \
-        \                 Log-Likelihood:       -5,973.144\nBIC:                 \
-        \              LL-Null:              -5,995.932\n=======================================================================\n\
+        \                 Log-Likelihood:       -5,717.211\nBIC:                 \
+        \              LL-Null:              -5,717.319\n=======================================================================\n\
         \                        coef   std err         z     P>|z|   Conf. Int.\n\
         -----------------------------------------------------------------------\n\
-        res_price_per_sqft    0.0005     0.000     9.968                       \n\
+        res_price_per_sqft    0.0000     0.000     0.547                       \n\
         ======================================================================="
     tags:
     - sam

--- a/configs/modelmanager_configs.yaml
+++ b/configs/modelmanager_configs.yaml
@@ -1,5 +1,141 @@
 modelmanager_version: 0.1dev5
 
+model_one:
+    filters: null
+    fitted_parameters:
+    - 0.09686869696923237
+    - 1.090087186229519e-05
+    - 0.012178554390128682
+    - -0.41168334895602865
+    model_expression: hownrent ~ income + persons + stories
+    name: model_one
+    out_column: taz
+    out_filters: null
+    out_tables: null
+    out_transform: null
+    out_value_false: 0
+    out_value_true: 1000000
+    summary_table: "                           Logit Regression Results          \
+        \                 \n==============================================================================\n\
+        Dep. Variable:               hownrent   No. Observations:              2603610\n\
+        Model:                          Logit   Df Residuals:                  2603606\n\
+        Method:                           MLE   Df Model:                        \
+        \    3\nDate:                Sat, 17 Mar 2018   Pseudo R-squ.:           \
+        \      0.08698\nTime:                        11:15:05   Log-Likelihood:  \
+        \          -1.6113e+06\nconverged:                       True   LL-Null: \
+        \                  -1.7649e+06\n                                        LLR\
+        \ p-value:                     0.000\n==============================================================================\n\
+        \                 coef    std err          z      P>|z|      [0.025      0.975]\n\
+        ------------------------------------------------------------------------------\n\
+        Intercept      0.0969      0.004     24.134      0.000       0.089       0.105\n\
+        income       1.09e-05   2.74e-08    397.741      0.000    1.08e-05     1.1e-05\n\
+        persons        0.0122      0.001     14.276      0.000       0.011       0.014\n\
+        stories       -0.4117      0.002   -201.179      0.000      -0.416      -0.408\n\
+        =============================================================================="
+    tables:
+    - households
+    - buildings
+    tags:
+    - sam
+    - testing
+    type: BinaryLogitStep
+
+model_two:
+    filters: null
+    fitted_parameters:
+    - 0.09686869696923237
+    - 1.090087186229519e-05
+    - 0.012178554390128682
+    - -0.41168334895602865
+    model_expression: hownrent ~ income + persons + stories
+    name: model_two
+    out_column: taz
+    out_filters: null
+    out_tables: null
+    out_transform: null
+    out_value_false: 0
+    out_value_true: 1000000000
+    summary_table: "                           Logit Regression Results          \
+        \                 \n==============================================================================\n\
+        Dep. Variable:               hownrent   No. Observations:              2603610\n\
+        Model:                          Logit   Df Residuals:                  2603606\n\
+        Method:                           MLE   Df Model:                        \
+        \    3\nDate:                Sat, 17 Mar 2018   Pseudo R-squ.:           \
+        \      0.08698\nTime:                        11:15:05   Log-Likelihood:  \
+        \          -1.6113e+06\nconverged:                       True   LL-Null: \
+        \                  -1.7649e+06\n                                        LLR\
+        \ p-value:                     0.000\n==============================================================================\n\
+        \                 coef    std err          z      P>|z|      [0.025      0.975]\n\
+        ------------------------------------------------------------------------------\n\
+        Intercept      0.0969      0.004     24.134      0.000       0.089       0.105\n\
+        income       1.09e-05   2.74e-08    397.741      0.000    1.08e-05     1.1e-05\n\
+        persons        0.0122      0.001     14.276      0.000       0.011       0.014\n\
+        stories       -0.4117      0.002   -201.179      0.000      -0.416      -0.408\n\
+        =============================================================================="
+    tables:
+    - households
+    - buildings
+    tags:
+    - sam
+    - testing
+    type: BinaryLogitStep
+
+small-mnl-test:
+    choice_column: tenure
+    filters:
+    - household_id % 1000 < 1
+    - tenure < 4
+    initial_coefs:
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    model_expression: null
+    model_expression_keys:
+    - intercept
+    - income
+    - persons
+    model_expression_values:
+    -   - 2
+        - 3
+    -   - 1
+        - 3
+    -   - 1
+        - 3
+    model_labels: null
+    name: small-mnl-test
+    out_column: taz
+    out_filters: null
+    out_tables: null
+    out_transform: null
+    summary_table: "                     Multinomial Logit Model Regression Results\
+        \                    \n===================================================================================\n\
+        Dep. Variable:                     _chosen   No. Observations:           \
+        \     2,575\nModel:             Multinomial Logit Model   Df Residuals:  \
+        \                  2,569\nMethod:                                MLE   Df\
+        \ Model:                            6\nDate:                     Fri, 23 Mar\
+        \ 2018   Pseudo R-squ.:                   0.145\nTime:                   \
+        \          21:35:44   Pseudo R-bar-squ.:               0.143\nAIC:       \
+        \                      4,850.866   Log-Likelihood:             -2,419.433\n\
+        BIC:                             4,885.988   LL-Null:                    -2,828.927\n\
+        ===============================================================================\n\
+        \                  coef    std err          z      P>|z|      [0.025     \
+        \ 0.975]\n-------------------------------------------------------------------------------\n\
+        intercept_2     0.0230      0.132      0.174      0.862      -0.236      \
+        \ 0.282\nintercept_3     1.0465      0.100     10.498      0.000       0.851\
+        \       1.242\nincome_1     5.679e-06   9.82e-07      5.782      0.000   \
+        \ 3.75e-06     7.6e-06\nincome_3    -6.051e-06   1.17e-06     -5.156     \
+        \ 0.000   -8.35e-06   -3.75e-06\npersons_1       0.2631      0.045      5.881\
+        \      0.000       0.175       0.351\npersons_3       0.1563      0.046  \
+        \    3.431      0.001       0.067       0.246\n==============================================================================="
+    tables: households
+    tags:
+    - sam
+    - testing
+    type: SmallMultinomialLogitStep
+
 ols-test:
     filters: null
     fitted_parameters:
@@ -79,142 +215,6 @@ ols-test:
     type: OLSRegressionStep
     version: 0.1dev1
 
-small-mnl-test:
-    choice_column: tenure
-    filters:
-    - household_id % 1000 < 1
-    - tenure < 4
-    initial_coefs:
-    - 0.0
-    - 0.0
-    - 0.0
-    - 0.0
-    - 0.0
-    - 0.0
-    model_expression: null
-    model_expression_keys:
-    - intercept
-    - income
-    - persons
-    model_expression_values:
-    -   - 2
-        - 3
-    -   - 1
-        - 3
-    -   - 1
-        - 3
-    model_labels: null
-    name: small-mnl-test
-    out_column: taz
-    out_filters: null
-    out_tables: null
-    out_transform: null
-    summary_table: "                     Multinomial Logit Model Regression Results\
-        \                    \n===================================================================================\n\
-        Dep. Variable:                     _chosen   No. Observations:           \
-        \     2,575\nModel:             Multinomial Logit Model   Df Residuals:  \
-        \                  2,569\nMethod:                                MLE   Df\
-        \ Model:                            6\nDate:                     Fri, 23 Mar\
-        \ 2018   Pseudo R-squ.:                   0.145\nTime:                   \
-        \          21:35:44   Pseudo R-bar-squ.:               0.143\nAIC:       \
-        \                      4,850.866   Log-Likelihood:             -2,419.433\n\
-        BIC:                             4,885.988   LL-Null:                    -2,828.927\n\
-        ===============================================================================\n\
-        \                  coef    std err          z      P>|z|      [0.025     \
-        \ 0.975]\n-------------------------------------------------------------------------------\n\
-        intercept_2     0.0230      0.132      0.174      0.862      -0.236      \
-        \ 0.282\nintercept_3     1.0465      0.100     10.498      0.000       0.851\
-        \       1.242\nincome_1     5.679e-06   9.82e-07      5.782      0.000   \
-        \ 3.75e-06     7.6e-06\nincome_3    -6.051e-06   1.17e-06     -5.156     \
-        \ 0.000   -8.35e-06   -3.75e-06\npersons_1       0.2631      0.045      5.881\
-        \      0.000       0.175       0.351\npersons_3       0.1563      0.046  \
-        \    3.431      0.001       0.067       0.246\n==============================================================================="
-    tables: households
-    tags:
-    - sam
-    - testing
-    type: SmallMultinomialLogitStep
-
-model_two:
-    filters: null
-    fitted_parameters:
-    - 0.09686869696923237
-    - 1.090087186229519e-05
-    - 0.012178554390128682
-    - -0.41168334895602865
-    model_expression: hownrent ~ income + persons + stories
-    name: model_two
-    out_column: taz
-    out_filters: null
-    out_tables: null
-    out_transform: null
-    out_value_false: 0
-    out_value_true: 1000000000
-    summary_table: "                           Logit Regression Results          \
-        \                 \n==============================================================================\n\
-        Dep. Variable:               hownrent   No. Observations:              2603610\n\
-        Model:                          Logit   Df Residuals:                  2603606\n\
-        Method:                           MLE   Df Model:                        \
-        \    3\nDate:                Sat, 17 Mar 2018   Pseudo R-squ.:           \
-        \      0.08698\nTime:                        11:15:05   Log-Likelihood:  \
-        \          -1.6113e+06\nconverged:                       True   LL-Null: \
-        \                  -1.7649e+06\n                                        LLR\
-        \ p-value:                     0.000\n==============================================================================\n\
-        \                 coef    std err          z      P>|z|      [0.025      0.975]\n\
-        ------------------------------------------------------------------------------\n\
-        Intercept      0.0969      0.004     24.134      0.000       0.089       0.105\n\
-        income       1.09e-05   2.74e-08    397.741      0.000    1.08e-05     1.1e-05\n\
-        persons        0.0122      0.001     14.276      0.000       0.011       0.014\n\
-        stories       -0.4117      0.002   -201.179      0.000      -0.416      -0.408\n\
-        =============================================================================="
-    tables:
-    - households
-    - buildings
-    tags:
-    - sam
-    - testing
-    type: BinaryLogitStep
-
-model_one:
-    filters: null
-    fitted_parameters:
-    - 0.09686869696923237
-    - 1.090087186229519e-05
-    - 0.012178554390128682
-    - -0.41168334895602865
-    model_expression: hownrent ~ income + persons + stories
-    name: model_one
-    out_column: taz
-    out_filters: null
-    out_tables: null
-    out_transform: null
-    out_value_false: 0
-    out_value_true: 1000000
-    summary_table: "                           Logit Regression Results          \
-        \                 \n==============================================================================\n\
-        Dep. Variable:               hownrent   No. Observations:              2603610\n\
-        Model:                          Logit   Df Residuals:                  2603606\n\
-        Method:                           MLE   Df Model:                        \
-        \    3\nDate:                Sat, 17 Mar 2018   Pseudo R-squ.:           \
-        \      0.08698\nTime:                        11:15:05   Log-Likelihood:  \
-        \          -1.6113e+06\nconverged:                       True   LL-Null: \
-        \                  -1.7649e+06\n                                        LLR\
-        \ p-value:                     0.000\n==============================================================================\n\
-        \                 coef    std err          z      P>|z|      [0.025      0.975]\n\
-        ------------------------------------------------------------------------------\n\
-        Intercept      0.0969      0.004     24.134      0.000       0.089       0.105\n\
-        income       1.09e-05   2.74e-08    397.741      0.000    1.08e-05     1.1e-05\n\
-        persons        0.0122      0.001     14.276      0.000       0.011       0.014\n\
-        stories       -0.4117      0.002   -201.179      0.000      -0.416      -0.408\n\
-        =============================================================================="
-    tables:
-    - households
-    - buildings
-    tags:
-    - sam
-    - testing
-    type: BinaryLogitStep
-
 large-mnl-test:
     alt_filters: null
     alt_sample_size: 10
@@ -226,7 +226,7 @@ large-mnl-test:
     - household_id % 1000 < 1
     choosers: households
     fitted_parameters:
-    - -2.941252961766151e-07
+    - 1.4474041623995042e-05
     model_expression: res_price_per_sqft - 1
     name: large-mnl-test
     out_alt_filters: null
@@ -241,11 +241,11 @@ large-mnl-test:
         \     Maximum Likelihood   Df Model:                       \nDate:       \
         \                       Pseudo R-squ.:                  \nTime:          \
         \                    Pseudo R-bar-squ.:              \nAIC:              \
-        \                 Log-Likelihood:       -5,717.319\nBIC:                 \
+        \                 Log-Likelihood:       -5,717.265\nBIC:                 \
         \              LL-Null:              -5,717.319\n=======================================================================\n\
         \                        coef   std err         z     P>|z|   Conf. Int.\n\
         -----------------------------------------------------------------------\n\
-        res_price_per_sqft   -0.0000     0.000    -0.009                       \n\
+        res_price_per_sqft    0.0000     0.000     0.432                       \n\
         ======================================================================="
     tags:
     - sam

--- a/configs/modelmanager_configs.yaml
+++ b/configs/modelmanager_configs.yaml
@@ -226,7 +226,7 @@ large-mnl-test:
     - household_id % 1000 < 1
     choosers: households
     fitted_parameters:
-    - 1.805049467592521e-05
+    - -2.941252961766151e-07
     model_expression: res_price_per_sqft - 1
     name: large-mnl-test
     out_alt_filters: null
@@ -241,11 +241,11 @@ large-mnl-test:
         \     Maximum Likelihood   Df Model:                       \nDate:       \
         \                       Pseudo R-squ.:                  \nTime:          \
         \                    Pseudo R-bar-squ.:              \nAIC:              \
-        \                 Log-Likelihood:       -5,717.211\nBIC:                 \
+        \                 Log-Likelihood:       -5,717.319\nBIC:                 \
         \              LL-Null:              -5,717.319\n=======================================================================\n\
         \                        coef   std err         z     P>|z|   Conf. Int.\n\
         -----------------------------------------------------------------------\n\
-        res_price_per_sqft    0.0000     0.000     0.547                       \n\
+        res_price_per_sqft   -0.0000     0.000    -0.009                       \n\
         ======================================================================="
     tags:
     - sam

--- a/notebooks-sam/Large-MNL-work.ipynb
+++ b/notebooks-sam/Large-MNL-work.ipynb
@@ -182,15 +182,15 @@
       "Method:       Maximum Likelihood   Df Model:                       \n",
       "Date:                              Pseudo R-squ.:                  \n",
       "Time:                              Pseudo R-bar-squ.:              \n",
-      "AIC:                               Log-Likelihood:       -5,717.319\n",
+      "AIC:                               Log-Likelihood:       -5,717.265\n",
       "BIC:                               LL-Null:              -5,717.319\n",
       "=======================================================================\n",
       "                        coef   std err         z     P>|z|   Conf. Int.\n",
       "-----------------------------------------------------------------------\n",
-      "res_price_per_sqft   -0.0000     0.000    -0.009                       \n",
+      "res_price_per_sqft    0.0000     0.000     0.432                       \n",
       "=======================================================================\n",
-      "CPU times: user 2.7 s, sys: 1.62 s, total: 4.33 s\n",
-      "Wall time: 4.3 s\n"
+      "CPU times: user 2.64 s, sys: 1.53 s, total: 4.17 s\n",
+      "Wall time: 4.14 s\n"
      ]
     }
    ],
@@ -209,7 +209,7 @@
     {
      "data": {
       "text/plain": [
-       "[-2.941252961766151e-07]"
+       "[1.4474041623995042e-05]"
       ]
      },
      "execution_count": 9,
@@ -242,7 +242,7 @@
     {
      "data": {
       "text/plain": [
-       "[-2.941252961766151e-07]"
+       "[1.4474041623995042e-05]"
       ]
      },
      "execution_count": 11,
@@ -299,14 +299,39 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 2.53 s, sys: 1.56 s, total: 4.09 s\n",
-      "Wall time: 4.06 s\n"
+      "Warning: choices are unconstrained; additional functionality in progress\n",
+      "CPU times: user 2.62 s, sys: 1.56 s, total: 4.18 s\n",
+      "Wall time: 4.15 s\n"
      ]
     }
    ],
    "source": [
     "%%time\n",
     "m.run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   observation_id  unit_id  probability\n",
+      "0              17  1729708     0.102294\n",
+      "1              17  1554523     0.099769\n",
+      "2              17   462748     0.099666\n",
+      "3              17   245026     0.099663\n",
+      "4              17   342047     0.099565\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(m.probabilities.head())"
    ]
   },
   {
@@ -320,22 +345,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "   observation_id  unit_id  probability\n",
-      "0              17  1659707     0.100000\n",
-      "1              17   917898     0.100003\n",
-      "2              17   823956     0.099994\n",
-      "3              17   501589     0.100010\n",
-      "4              17  1905583     0.100013\n"
+      "17       342047\n",
+      "1017    2236440\n",
+      "2017    2658856\n",
+      "3017    2778429\n",
+      "4017    1881991\n",
+      "Name: choice, dtype: int64\n"
      ]
     }
    ],
    "source": [
-    "print(m.probabilities.head())"
+    "print(m.choices.head())"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 25,
    "metadata": {
     "collapsed": false
    },
@@ -344,17 +369,54 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "17      1659707\n",
-      "1017    1107809\n",
-      "2017     652905\n",
-      "3017    1557673\n",
-      "4017    1102333\n",
-      "Name: choice, dtype: int64\n"
+      "   observation_id  unit_id  probability  choice  chosen\n",
+      "0              17  1729708     0.102294  342047       0\n",
+      "1              17  1554523     0.099769  342047       0\n",
+      "2              17   462748     0.099666  342047       0\n",
+      "3              17   245026     0.099663  342047       0\n",
+      "4              17   342047     0.099565  342047       1\n",
+      "[[ 1.00000000e+00 -5.76017762e-04]\n",
+      " [-5.76017762e-04  1.00000000e+00]]\n"
      ]
     }
    ],
    "source": [
-    "print(m.choices.head())"
+    "# Check that choices are plausible\n",
+    "choices = pd.DataFrame(m.choices)\n",
+    "df = pd.merge(m.probabilities, choices, left_on='observation_id', right_index=True)\n",
+    "df['chosen'] = 0\n",
+    "df.loc[df.unit_id == df.choice, 'chosen'] = 1\n",
+    "print(df.head())\n",
+    "print(np.corrcoef(df.probability, df.chosen))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "That seems wrong (correlation should be positive), but I don't know why. Better to test with a more informative model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "342047\n",
+      "2236440\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Check that choices are saved correctly\n",
+    "print(orca.get_table('households').to_frame().loc[17, 'unit_id'])\n",
+    "print(orca.get_table('households').to_frame().loc[1017, 'unit_id'])"
    ]
   },
   {

--- a/notebooks-sam/Large-MNL-work.ipynb
+++ b/notebooks-sam/Large-MNL-work.ipynb
@@ -6,14 +6,14 @@
    "source": [
     "# Large MNL work\n",
     "\n",
-    "Sam Maurer, April 2018 | Python 3.6\n",
+    "Sam Maurer, April 2018 (last updated June 2018) - Python 3.6\n",
     "\n",
     "This notebook is for development, testing, and demonstration of the template for MNL with large numbers of alternatives."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {
     "collapsed": true
    },
@@ -24,7 +24,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {
     "collapsed": true
    },
@@ -36,7 +36,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {
     "collapsed": false
    },
@@ -58,7 +58,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {
     "collapsed": true
    },
@@ -71,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {
     "collapsed": false
    },
@@ -80,11 +80,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "HOUSEHOLDS\n",
-      "['household_id', 'taz', 'serialno', 'puma5', 'income', 'persons', 'hht', 'unittype', 'noc', 'bldgsz', 'tenure', 'vehicl', 'hinccat1', 'hinccat2', 'hhagecat', 'hsizecat', 'hfamily', 'hunittype', 'hnoccat', 'hwrkrcat', 'h0004', 'h0511', 'h1215', 'h1617', 'h1824', 'h2534', 'h3549', 'h5064', 'h6579', 'h80up', 'hworkers', 'hwork_f', 'hwork_p', 'huniv', 'hnwork', 'hretire', 'hpresch', 'hschpred', 'hschdriv', 'htypdwel', 'hownrent', 'hadnwst', 'hadwpst', 'hadkids', 'bucketbin', 'originalpuma', 'hmultiunit', 'building_id']\n",
+      "PARCELS\n",
+      "['development_type_id', 'land_value', 'acres', 'county_id', 'zone_id', 'proportion_undevelopable', 'tax_exempt_status', 'apn', 'parcel_id_local', 'geom_id', 'imputation_flag', 'x', 'y', 'shape_area', 'block_id', 'node_id']\n",
       "\n",
       "BUILDINGS\n",
-      "['building_id', 'parcel_id', 'development_type_id', 'improvement_value', 'residential_units', 'residential_sqft', 'sqft_per_unit', 'non_residential_sqft', 'building_sqft', 'nonres_rent_per_sqft', 'res_price_per_sqft', 'stories', 'year_built', 'redfin_sale_price', 'redfin_sale_year', 'redfin_home_type', 'costar_property_type', 'costar_rent', 'building_type_id']\n",
+      "['parcel_id', 'development_type_id', 'improvement_value', 'residential_units', 'residential_sqft', 'sqft_per_unit', 'non_residential_sqft', 'building_sqft', 'nonres_rent_per_sqft', 'res_price_per_sqft', 'stories', 'year_built', 'redfin_sale_price', 'redfin_sale_year', 'redfin_home_type', 'costar_property_type', 'costar_rent', 'building_type_id']\n",
+      "\n",
+      "UNITS\n",
+      "['Unnamed: 0', 'building_id', 'num_units', 'tenure', 'unit_num', 'unit_residential_price', 'unit_residential_rent']\n",
+      "\n",
+      "HOUSEHOLDS\n",
+      "['household_id', 'serialno', 'persons', 'building_type', 'cars', 'income', 'race_of_head', 'hispanic_head', 'age_of_head', 'workers', 'state', 'county', 'tract', 'block group', 'children', 'tenure', 'recent_mover', 'block_group_id', 'single_family', 'unit_id']\n",
+      "\n",
+      "PERSONS\n",
+      "['Unnamed: 0', 'member_id', 'age', 'relate', 'edu', 'sex', 'hours', 'hispanic', 'earning', 'race_id', 'hispanic.1', 'household_id', 'student', 'work_at_home', 'worker']\n",
       "\n"
      ]
     }
@@ -114,7 +123,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {
     "collapsed": false
    },
@@ -122,8 +131,8 @@
    "source": [
     "m = LargeMultinomialLogitStep()\n",
     "m.choosers = ['households']\n",
-    "m.alternatives = ['buildings']\n",
-    "m.choice_column = 'building_id'\n",
+    "m.alternatives = ['units', 'buildings']\n",
+    "m.choice_column = 'unit_id'\n",
     "m.alt_sample_size = 10\n",
     "m.chooser_filters = ['household_id % 1000 < 1']\n",
     "\n",
@@ -135,7 +144,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {
     "collapsed": false
    },
@@ -143,10 +152,10 @@
     {
      "data": {
       "text/plain": [
-       "2608"
+       "2680"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -157,7 +166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {
     "collapsed": false
    },
@@ -173,15 +182,15 @@
       "Method:       Maximum Likelihood   Df Model:                       \n",
       "Date:                              Pseudo R-squ.:                  \n",
       "Time:                              Pseudo R-bar-squ.:              \n",
-      "AIC:                               Log-Likelihood:       -5,973.144\n",
-      "BIC:                               LL-Null:              -5,995.932\n",
+      "AIC:                               Log-Likelihood:       -5,717.211\n",
+      "BIC:                               LL-Null:              -5,717.319\n",
       "=======================================================================\n",
       "                        coef   std err         z     P>|z|   Conf. Int.\n",
       "-----------------------------------------------------------------------\n",
-      "res_price_per_sqft    0.0005     0.000     9.968                       \n",
+      "res_price_per_sqft    0.0000     0.000     0.547                       \n",
       "=======================================================================\n",
-      "CPU times: user 753 ms, sys: 445 ms, total: 1.2 s\n",
-      "Wall time: 1.17 s\n"
+      "CPU times: user 2.64 s, sys: 1.56 s, total: 4.21 s\n",
+      "Wall time: 4.18 s\n"
      ]
     }
    ],
@@ -192,7 +201,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {
     "collapsed": false
    },
@@ -200,10 +209,10 @@
     {
      "data": {
       "text/plain": [
-       "[0.00045990926356891706]"
+       "[1.805049467592521e-05]"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -214,7 +223,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {
     "collapsed": true
    },
@@ -225,7 +234,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {
     "collapsed": false
    },
@@ -233,10 +242,10 @@
     {
      "data": {
       "text/plain": [
-       "[0.00045990926356891706]"
+       "[1.805049467592521e-05]"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -247,7 +256,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {
     "collapsed": false
    },
@@ -258,7 +267,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {
     "collapsed": false
    },
@@ -267,6 +276,35 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "     index  Unnamed: 0  building_id  num_units  tenure  unit_num  \\\n",
+      "0  1407230     1407230        15667          1       2       851   \n",
+      "1   691890      691890        44508          1       1         0   \n",
+      "2  1932296     1932296        92604          1       2         1   \n",
+      "3  2075210     2075210        48439          1       2         0   \n",
+      "4   838069      838069      1798691          1       1         0   \n",
+      "\n",
+      "   unit_residential_price  unit_residential_rent  parcel_id  \\\n",
+      "0                       0                      0    1259982   \n",
+      "1                       0                      0     607765   \n",
+      "2                       0                      0    1802764   \n",
+      "3                       0                      0    1884977   \n",
+      "4                       0                      0     607881   \n",
+      "\n",
+      "   development_type_id   ...    county   tract  block group  children  \\\n",
+      "0                    2   ...        85  500901            1       NaN   \n",
+      "1                    1   ...        85  500901            1       NaN   \n",
+      "2                    1   ...        85  500901            1       NaN   \n",
+      "3                    1   ...        85  500901            1       NaN   \n",
+      "4                    1   ...        85  500901            1       NaN   \n",
+      "\n",
+      "   tenure_r  recent_mover  block_group_id  single_family  unit_id  chosen  \n",
+      "0         2             0     60855009011          False  1711616       1  \n",
+      "1         2             0     60855009011          False  1711616       0  \n",
+      "2         2             0     60855009011          False  1711616       0  \n",
+      "3         2             0     60855009011          False  1711616       0  \n",
+      "4         2             0     60855009011          False  1711616       0  \n",
+      "\n",
+      "[5 rows x 48 columns]\n",
       "None\n"
      ]
     },
@@ -277,13 +315,13 @@
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-14-db82cbb0f449>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mget_ipython\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mrun_cell_magic\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'time'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m''\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'm.run()'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m<ipython-input-13-db82cbb0f449>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mget_ipython\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mrun_cell_magic\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'time'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m''\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'm.run()'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
       "\u001b[0;32m/Users/maurer/anaconda/lib/python3.6/site-packages/IPython/core/interactiveshell.py\u001b[0m in \u001b[0;36mrun_cell_magic\u001b[0;34m(self, magic_name, line, cell)\u001b[0m\n\u001b[1;32m   2113\u001b[0m             \u001b[0mmagic_arg_s\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mvar_expand\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mline\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mstack_depth\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2114\u001b[0m             \u001b[0;32mwith\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mbuiltin_trap\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 2115\u001b[0;31m                 \u001b[0mresult\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmagic_arg_s\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcell\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   2116\u001b[0m             \u001b[0;32mreturn\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2117\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
       "\u001b[0;32m<decorator-gen-59>\u001b[0m in \u001b[0;36mtime\u001b[0;34m(self, line, cell, local_ns)\u001b[0m\n",
       "\u001b[0;32m/Users/maurer/anaconda/lib/python3.6/site-packages/IPython/core/magic.py\u001b[0m in \u001b[0;36m<lambda>\u001b[0;34m(f, *a, **k)\u001b[0m\n\u001b[1;32m    186\u001b[0m     \u001b[0;31m# but it's overkill for just that one bit of state.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    187\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mmagic_deco\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0marg\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 188\u001b[0;31m         \u001b[0mcall\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mlambda\u001b[0m \u001b[0mf\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0ma\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mk\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mf\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0ma\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mk\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    189\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    190\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mcallable\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0marg\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
       "\u001b[0;32m/Users/maurer/anaconda/lib/python3.6/site-packages/IPython/core/magics/execution.py\u001b[0m in \u001b[0;36mtime\u001b[0;34m(self, line, cell, local_ns)\u001b[0m\n\u001b[1;32m   1174\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m==\u001b[0m\u001b[0;34m'eval'\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1175\u001b[0m             \u001b[0mst\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mclock2\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1176\u001b[0;31m             \u001b[0mout\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0meval\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcode\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mglob\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mlocal_ns\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1177\u001b[0m             \u001b[0mend\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mclock2\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1178\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
       "\u001b[0;32m<timed eval>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n",
-      "\u001b[0;32m/Users/maurer/Dropbox/Git-imac/udst/urbansim_templates/urbansim_templates/models/large_multinomial_logit.py\u001b[0m in \u001b[0;36mrun\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    367\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    368\u001b[0m         \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdata\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0malternative_id_col\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 369\u001b[0;31m         \u001b[0mids\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mdata\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mto_frame\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mdata\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0malternative_id_col\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtolist\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    370\u001b[0m         \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mids\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;36m20\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    371\u001b[0m         \u001b[0mchoices\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_get_chosen_ids\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mids\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mchoice_positions\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/Users/maurer/Dropbox/Git-imac/udst/urbansim_templates/urbansim_templates/models/large_multinomial_logit.py\u001b[0m in \u001b[0;36mrun\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    371\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    372\u001b[0m         \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdata\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0malternative_id_col\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 373\u001b[0;31m         \u001b[0mids\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mdata\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mto_frame\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mdata\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0malternative_id_col\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtolist\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    374\u001b[0m         \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mids\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;36m20\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    375\u001b[0m         \u001b[0mchoices\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_get_chosen_ids\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mids\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mchoice_positions\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
       "\u001b[0;32m/Users/maurer/anaconda/lib/python3.6/site-packages/pandas/core/frame.py\u001b[0m in \u001b[0;36m__getitem__\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m   2137\u001b[0m             \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_getitem_multilevel\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2138\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 2139\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_getitem_column\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   2140\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2141\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_getitem_column\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mkey\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
       "\u001b[0;32m/Users/maurer/anaconda/lib/python3.6/site-packages/pandas/core/frame.py\u001b[0m in \u001b[0;36m_getitem_column\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m   2144\u001b[0m         \u001b[0;31m# get column\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2145\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcolumns\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mis_unique\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 2146\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_get_item_cache\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   2147\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2148\u001b[0m         \u001b[0;31m# duplicate columns & possible reduce dimensionality\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
       "\u001b[0;32m/Users/maurer/anaconda/lib/python3.6/site-packages/pandas/core/generic.py\u001b[0m in \u001b[0;36m_get_item_cache\u001b[0;34m(self, item)\u001b[0m\n\u001b[1;32m   1840\u001b[0m         \u001b[0mres\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mcache\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mitem\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1841\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mres\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1842\u001b[0;31m             \u001b[0mvalues\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_data\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mitem\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1843\u001b[0m             \u001b[0mres\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_box_item_values\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mitem\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mvalues\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1844\u001b[0m             \u001b[0mcache\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mitem\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mres\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
@@ -332,6 +370,18 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,

--- a/notebooks-sam/Large-MNL-work.ipynb
+++ b/notebooks-sam/Large-MNL-work.ipynb
@@ -60,7 +60,7 @@
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -182,15 +182,15 @@
       "Method:       Maximum Likelihood   Df Model:                       \n",
       "Date:                              Pseudo R-squ.:                  \n",
       "Time:                              Pseudo R-bar-squ.:              \n",
-      "AIC:                               Log-Likelihood:       -5,717.211\n",
+      "AIC:                               Log-Likelihood:       -5,717.319\n",
       "BIC:                               LL-Null:              -5,717.319\n",
       "=======================================================================\n",
       "                        coef   std err         z     P>|z|   Conf. Int.\n",
       "-----------------------------------------------------------------------\n",
-      "res_price_per_sqft    0.0000     0.000     0.547                       \n",
+      "res_price_per_sqft   -0.0000     0.000    -0.009                       \n",
       "=======================================================================\n",
-      "CPU times: user 2.64 s, sys: 1.56 s, total: 4.21 s\n",
-      "Wall time: 4.18 s\n"
+      "CPU times: user 2.7 s, sys: 1.62 s, total: 4.33 s\n",
+      "Wall time: 4.3 s\n"
      ]
     }
    ],
@@ -209,7 +209,7 @@
     {
      "data": {
       "text/plain": [
-       "[1.805049467592521e-05]"
+       "[-2.941252961766151e-07]"
       ]
      },
      "execution_count": 9,
@@ -242,7 +242,7 @@
     {
      "data": {
       "text/plain": [
-       "[1.805049467592521e-05]"
+       "[-2.941252961766151e-07]"
       ]
      },
      "execution_count": 11,
@@ -276,57 +276,31 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "     index  Unnamed: 0  building_id  num_units  tenure  unit_num  \\\n",
-      "0  1407230     1407230        15667          1       2       851   \n",
-      "1   691890      691890        44508          1       1         0   \n",
-      "2  1932296     1932296        92604          1       2         1   \n",
-      "3  2075210     2075210        48439          1       2         0   \n",
-      "4   838069      838069      1798691          1       1         0   \n",
-      "\n",
-      "   unit_residential_price  unit_residential_rent  parcel_id  \\\n",
-      "0                       0                      0    1259982   \n",
-      "1                       0                      0     607765   \n",
-      "2                       0                      0    1802764   \n",
-      "3                       0                      0    1884977   \n",
-      "4                       0                      0     607881   \n",
-      "\n",
-      "   development_type_id   ...    county   tract  block group  children  \\\n",
-      "0                    2   ...        85  500901            1       NaN   \n",
-      "1                    1   ...        85  500901            1       NaN   \n",
-      "2                    1   ...        85  500901            1       NaN   \n",
-      "3                    1   ...        85  500901            1       NaN   \n",
-      "4                    1   ...        85  500901            1       NaN   \n",
-      "\n",
-      "   tenure_r  recent_mover  block_group_id  single_family  unit_id  chosen  \n",
-      "0         2             0     60855009011          False  1711616       1  \n",
-      "1         2             0     60855009011          False  1711616       0  \n",
-      "2         2             0     60855009011          False  1711616       0  \n",
-      "3         2             0     60855009011          False  1711616       0  \n",
-      "4         2             0     60855009011          False  1711616       0  \n",
-      "\n",
-      "[5 rows x 48 columns]\n",
-      "None\n"
+      "RangeIndex(start=0, stop=2784008, step=1, name='unit_id')\n",
+      "RangeIndex(start=0, stop=2784008, step=1, name='unit_id')\n"
      ]
-    },
+    }
+   ],
+   "source": [
+    "df = orca.get_table('units').to_frame()\n",
+    "print(df.index)\n",
+    "df.index.name = 'unit_id'\n",
+    "print(df.index)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
     {
-     "ename": "ValueError",
-     "evalue": "cannot label index with a null key",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-13-db82cbb0f449>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mget_ipython\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mrun_cell_magic\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'time'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m''\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'm.run()'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m/Users/maurer/anaconda/lib/python3.6/site-packages/IPython/core/interactiveshell.py\u001b[0m in \u001b[0;36mrun_cell_magic\u001b[0;34m(self, magic_name, line, cell)\u001b[0m\n\u001b[1;32m   2113\u001b[0m             \u001b[0mmagic_arg_s\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mvar_expand\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mline\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mstack_depth\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2114\u001b[0m             \u001b[0;32mwith\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mbuiltin_trap\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 2115\u001b[0;31m                 \u001b[0mresult\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmagic_arg_s\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcell\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   2116\u001b[0m             \u001b[0;32mreturn\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2117\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m<decorator-gen-59>\u001b[0m in \u001b[0;36mtime\u001b[0;34m(self, line, cell, local_ns)\u001b[0m\n",
-      "\u001b[0;32m/Users/maurer/anaconda/lib/python3.6/site-packages/IPython/core/magic.py\u001b[0m in \u001b[0;36m<lambda>\u001b[0;34m(f, *a, **k)\u001b[0m\n\u001b[1;32m    186\u001b[0m     \u001b[0;31m# but it's overkill for just that one bit of state.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    187\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mmagic_deco\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0marg\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 188\u001b[0;31m         \u001b[0mcall\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mlambda\u001b[0m \u001b[0mf\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0ma\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mk\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mf\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0ma\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mk\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    189\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    190\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mcallable\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0marg\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/Users/maurer/anaconda/lib/python3.6/site-packages/IPython/core/magics/execution.py\u001b[0m in \u001b[0;36mtime\u001b[0;34m(self, line, cell, local_ns)\u001b[0m\n\u001b[1;32m   1174\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m==\u001b[0m\u001b[0;34m'eval'\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1175\u001b[0m             \u001b[0mst\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mclock2\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1176\u001b[0;31m             \u001b[0mout\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0meval\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcode\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mglob\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mlocal_ns\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1177\u001b[0m             \u001b[0mend\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mclock2\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1178\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m<timed eval>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n",
-      "\u001b[0;32m/Users/maurer/Dropbox/Git-imac/udst/urbansim_templates/urbansim_templates/models/large_multinomial_logit.py\u001b[0m in \u001b[0;36mrun\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    371\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    372\u001b[0m         \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdata\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0malternative_id_col\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 373\u001b[0;31m         \u001b[0mids\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mdata\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mto_frame\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mdata\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0malternative_id_col\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtolist\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    374\u001b[0m         \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mids\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;36m20\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    375\u001b[0m         \u001b[0mchoices\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_get_chosen_ids\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mids\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mchoice_positions\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/Users/maurer/anaconda/lib/python3.6/site-packages/pandas/core/frame.py\u001b[0m in \u001b[0;36m__getitem__\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m   2137\u001b[0m             \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_getitem_multilevel\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2138\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 2139\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_getitem_column\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   2140\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2141\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_getitem_column\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mkey\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/Users/maurer/anaconda/lib/python3.6/site-packages/pandas/core/frame.py\u001b[0m in \u001b[0;36m_getitem_column\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m   2144\u001b[0m         \u001b[0;31m# get column\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2145\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcolumns\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mis_unique\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 2146\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_get_item_cache\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   2147\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2148\u001b[0m         \u001b[0;31m# duplicate columns & possible reduce dimensionality\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/Users/maurer/anaconda/lib/python3.6/site-packages/pandas/core/generic.py\u001b[0m in \u001b[0;36m_get_item_cache\u001b[0;34m(self, item)\u001b[0m\n\u001b[1;32m   1840\u001b[0m         \u001b[0mres\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mcache\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mitem\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1841\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mres\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1842\u001b[0;31m             \u001b[0mvalues\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_data\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mitem\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1843\u001b[0m             \u001b[0mres\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_box_item_values\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mitem\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mvalues\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1844\u001b[0m             \u001b[0mcache\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mitem\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mres\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/Users/maurer/anaconda/lib/python3.6/site-packages/pandas/core/internals.py\u001b[0m in \u001b[0;36mget\u001b[0;34m(self, item, fastpath)\u001b[0m\n\u001b[1;32m   3850\u001b[0m                         \u001b[0mloc\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mindexer\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mitem\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   3851\u001b[0m                     \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 3852\u001b[0;31m                         \u001b[0;32mraise\u001b[0m \u001b[0mValueError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"cannot label index with a null key\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   3853\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   3854\u001b[0m             \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0miget\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mloc\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfastpath\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mfastpath\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mValueError\u001b[0m: cannot label index with a null key"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 2.53 s, sys: 1.56 s, total: 4.09 s\n",
+      "Wall time: 4.06 s\n"
      ]
     }
    ],
@@ -337,14 +311,60 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   observation_id  unit_id  probability\n",
+      "0              17  1659707     0.100000\n",
+      "1              17   917898     0.100003\n",
+      "2              17   823956     0.099994\n",
+      "3              17   501589     0.100010\n",
+      "4              17  1905583     0.100013\n"
+     ]
+    }
+   ],
    "source": [
-    "m.choices"
+    "print(m.probabilities.head())"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "17      1659707\n",
+      "1017    1107809\n",
+      "2017     652905\n",
+      "3017    1557673\n",
+      "4017    1102333\n",
+      "Name: choice, dtype: int64\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(m.choices.head())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",

--- a/scripts/datasources.py
+++ b/scripts/datasources.py
@@ -39,6 +39,7 @@ def buildings():
 def units():
     z = zipfile.ZipFile(d + 'units_w_tenure.zip')
     df = pd.read_csv(z.open('units_w_tenure.csv'))
+    df.index.name = 'unit_id'  # first column in CSV is unnamed
     return df
 
 @orca.table(cache=True)
@@ -51,6 +52,7 @@ def households():
 def persons():
     z = zipfile.ZipFile(d + 'synthpop_w_units.zip')
     df = pd.read_csv(z.open('sfbay_persons_2018_04_16.csv'))
+    df.index.name = 'person_id'  # first column in CSV is unnamed
     return df
 
 


### PR DESCRIPTION
This PR merges some updates to my [Large-MNL.ipynb](https://github.com/ual/urbansim_parcel_bayarea/blob/0f15e5679e5ac89dd74fbc50790588ffca2538c2/notebooks-sam/Large-MNL-work.ipynb) notebook that demonstrate how we can now get probabilities and unconstrained choices from a large MNL model.

The underlying functionality is implemented in https://github.com/UDST/urbansim_templates/pull/14.

This PR also fixes a bug in `datasources.py` where the indexes of a couple of tables were unnamed, which meant we couldn't directly access those columns once the tables were in Orca.

cc @waddell @Arezoo-bz @mxndrwgrdnr 