### PR TITLE
Consistent model ordering

### DIFF
--- a/configs/modelmanager_configs.yaml
+++ b/configs/modelmanager_configs.yaml
@@ -1,5 +1,42 @@
 modelmanager_version: 0.1dev5
 
+large-mnl-test:
+    alt_filters: null
+    alt_sample_size: 10
+    alternatives:
+    - units
+    - buildings
+    choice_column: unit_id
+    chooser_filters:
+    - household_id % 1000 < 1
+    choosers: households
+    fitted_parameters:
+    - 1.4474041623995042e-05
+    model_expression: res_price_per_sqft - 1
+    name: large-mnl-test
+    out_alt_filters: null
+    out_alternatives: null
+    out_chooser_filters: null
+    out_choosers: null
+    out_column: null
+    summary_table: "                  CHOICEMODELS ESTIMATION RESULTS            \
+        \      \n===================================================================\n\
+        Dep. Var.:                chosen   No. Observations:               \nModel:\
+        \         Multinomial Logit   Df Residuals:                   \nMethod:  \
+        \     Maximum Likelihood   Df Model:                       \nDate:       \
+        \                       Pseudo R-squ.:                  \nTime:          \
+        \                    Pseudo R-bar-squ.:              \nAIC:              \
+        \                 Log-Likelihood:       -5,717.265\nBIC:                 \
+        \              LL-Null:              -5,717.319\n=======================================================================\n\
+        \                        coef   std err         z     P>|z|   Conf. Int.\n\
+        -----------------------------------------------------------------------\n\
+        res_price_per_sqft    0.0000     0.000     0.432                       \n\
+        ======================================================================="
+    tags:
+    - sam
+    - testing
+    type: LargeMultinomialLogitStep
+
 model_one:
     filters: null
     fitted_parameters:
@@ -80,62 +117,6 @@ model_two:
     - testing
     type: BinaryLogitStep
 
-small-mnl-test:
-    choice_column: tenure
-    filters:
-    - household_id % 1000 < 1
-    - tenure < 4
-    initial_coefs:
-    - 0.0
-    - 0.0
-    - 0.0
-    - 0.0
-    - 0.0
-    - 0.0
-    model_expression: null
-    model_expression_keys:
-    - intercept
-    - income
-    - persons
-    model_expression_values:
-    -   - 2
-        - 3
-    -   - 1
-        - 3
-    -   - 1
-        - 3
-    model_labels: null
-    name: small-mnl-test
-    out_column: taz
-    out_filters: null
-    out_tables: null
-    out_transform: null
-    summary_table: "                     Multinomial Logit Model Regression Results\
-        \                    \n===================================================================================\n\
-        Dep. Variable:                     _chosen   No. Observations:           \
-        \     2,575\nModel:             Multinomial Logit Model   Df Residuals:  \
-        \                  2,569\nMethod:                                MLE   Df\
-        \ Model:                            6\nDate:                     Fri, 23 Mar\
-        \ 2018   Pseudo R-squ.:                   0.145\nTime:                   \
-        \          21:35:44   Pseudo R-bar-squ.:               0.143\nAIC:       \
-        \                      4,850.866   Log-Likelihood:             -2,419.433\n\
-        BIC:                             4,885.988   LL-Null:                    -2,828.927\n\
-        ===============================================================================\n\
-        \                  coef    std err          z      P>|z|      [0.025     \
-        \ 0.975]\n-------------------------------------------------------------------------------\n\
-        intercept_2     0.0230      0.132      0.174      0.862      -0.236      \
-        \ 0.282\nintercept_3     1.0465      0.100     10.498      0.000       0.851\
-        \       1.242\nincome_1     5.679e-06   9.82e-07      5.782      0.000   \
-        \ 3.75e-06     7.6e-06\nincome_3    -6.051e-06   1.17e-06     -5.156     \
-        \ 0.000   -8.35e-06   -3.75e-06\npersons_1       0.2631      0.045      5.881\
-        \      0.000       0.175       0.351\npersons_3       0.1563      0.046  \
-        \    3.431      0.001       0.067       0.246\n==============================================================================="
-    tables: households
-    tags:
-    - sam
-    - testing
-    type: SmallMultinomialLogitStep
-
 ols-test:
     filters: null
     fitted_parameters:
@@ -215,39 +196,58 @@ ols-test:
     type: OLSRegressionStep
     version: 0.1dev1
 
-large-mnl-test:
-    alt_filters: null
-    alt_sample_size: 10
-    alternatives:
-    - units
-    - buildings
-    choice_column: unit_id
-    chooser_filters:
+small-mnl-test:
+    choice_column: tenure
+    filters:
     - household_id % 1000 < 1
-    choosers: households
-    fitted_parameters:
-    - 1.4474041623995042e-05
-    model_expression: res_price_per_sqft - 1
-    name: large-mnl-test
-    out_alt_filters: null
-    out_alternatives: null
-    out_chooser_filters: null
-    out_choosers: null
-    out_column: null
-    summary_table: "                  CHOICEMODELS ESTIMATION RESULTS            \
-        \      \n===================================================================\n\
-        Dep. Var.:                chosen   No. Observations:               \nModel:\
-        \         Multinomial Logit   Df Residuals:                   \nMethod:  \
-        \     Maximum Likelihood   Df Model:                       \nDate:       \
-        \                       Pseudo R-squ.:                  \nTime:          \
-        \                    Pseudo R-bar-squ.:              \nAIC:              \
-        \                 Log-Likelihood:       -5,717.265\nBIC:                 \
-        \              LL-Null:              -5,717.319\n=======================================================================\n\
-        \                        coef   std err         z     P>|z|   Conf. Int.\n\
-        -----------------------------------------------------------------------\n\
-        res_price_per_sqft    0.0000     0.000     0.432                       \n\
-        ======================================================================="
+    - tenure < 4
+    initial_coefs:
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    - 0.0
+    model_expression: null
+    model_expression_keys:
+    - intercept
+    - income
+    - persons
+    model_expression_values:
+    -   - 2
+        - 3
+    -   - 1
+        - 3
+    -   - 1
+        - 3
+    model_labels: null
+    name: small-mnl-test
+    out_column: taz
+    out_filters: null
+    out_tables: null
+    out_transform: null
+    summary_table: "                     Multinomial Logit Model Regression Results\
+        \                    \n===================================================================================\n\
+        Dep. Variable:                     _chosen   No. Observations:           \
+        \     2,575\nModel:             Multinomial Logit Model   Df Residuals:  \
+        \                  2,569\nMethod:                                MLE   Df\
+        \ Model:                            6\nDate:                     Fri, 23 Mar\
+        \ 2018   Pseudo R-squ.:                   0.145\nTime:                   \
+        \          21:35:44   Pseudo R-bar-squ.:               0.143\nAIC:       \
+        \                      4,850.866   Log-Likelihood:             -2,419.433\n\
+        BIC:                             4,885.988   LL-Null:                    -2,828.927\n\
+        ===============================================================================\n\
+        \                  coef    std err          z      P>|z|      [0.025     \
+        \ 0.975]\n-------------------------------------------------------------------------------\n\
+        intercept_2     0.0230      0.132      0.174      0.862      -0.236      \
+        \ 0.282\nintercept_3     1.0465      0.100     10.498      0.000       0.851\
+        \       1.242\nincome_1     5.679e-06   9.82e-07      5.782      0.000   \
+        \ 3.75e-06     7.6e-06\nincome_3    -6.051e-06   1.17e-06     -5.156     \
+        \ 0.000   -8.35e-06   -3.75e-06\npersons_1       0.2631      0.045      5.881\
+        \      0.000       0.175       0.351\npersons_3       0.1563      0.046  \
+        \    3.431      0.001       0.067       0.246\n==============================================================================="
+    tables: households
     tags:
     - sam
     - testing
-    type: LargeMultinomialLogitStep
+    type: SmallMultinomialLogitStep

--- a/notebooks-sam/Explore-data.ipynb
+++ b/notebooks-sam/Explore-data.ipynb
@@ -25,9 +25,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -59,9 +57,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stderr",
@@ -121,9 +117,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -157,9 +151,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -179,9 +171,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -201,9 +191,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -246,9 +234,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -267,9 +253,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -289,9 +273,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -328,9 +310,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -410,9 +390,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -429,9 +407,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -683,9 +659,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -721,9 +695,7 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -790,7 +762,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.2"
   }
  },
  "nbformat": 4,

--- a/notebooks-sam/Sandbox.ipynb
+++ b/notebooks-sam/Sandbox.ipynb
@@ -1,0 +1,196 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Sandbox\n",
+    "\n",
+    "Sam Maurer, June 2018 | Python 3.6\n",
+    "\n",
+    "This notebook is a sandbox for feature development and testing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import os; os.chdir('../')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'/Users/maurer/Dropbox/Git-mbp13/ual/urbansim_parcel_bayarea'"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "os.getcwd()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/maurer/anaconda3/lib/python3.6/site-packages/statsmodels/compat/pandas.py:56: FutureWarning: The pandas.core.datetools module is deprecated and will be removed in a future version. Please use the pandas.tseries module instead.\n",
+      "  from pandas.core import datetools\n"
+     ]
+    }
+   ],
+   "source": [
+    "from urbansim_templates import modelmanager as mm\n",
+    "import orca"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Run this cell to override the standard data directory, if needed\n",
+    "orca.add_injectable('data_directory', '/home/data/')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Load script-based Orca registrations\n",
+    "from scripts import datasources\n",
+    "from scripts import models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Model-save-order\n",
+    "\n",
+    "Testing a bug fix: ModelManager should store model steps in a consistent order."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'name': 'large-mnl-test',\n",
+       "  'tags': ['sam', 'testing'],\n",
+       "  'type': 'LargeMultinomialLogitStep'},\n",
+       " {'name': 'model_one', 'tags': ['sam', 'testing'], 'type': 'BinaryLogitStep'},\n",
+       " {'name': 'model_two', 'tags': ['sam', 'testing'], 'type': 'BinaryLogitStep'},\n",
+       " {'name': 'ols-test', 'tags': ['sam', 'testing'], 'type': 'OLSRegressionStep'},\n",
+       " {'name': 'small-mnl-test',\n",
+       "  'tags': ['sam', 'testing'],\n",
+       "  'type': 'SmallMultinomialLogitStep'}]"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mm.list_steps()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This PR updates `modelmanager_configs.yaml`: model steps are now stored in alphabetical order by name. (It also adds a sandbox notebook that i'm using for ongoing development and testing.)

The consistent ordering is implemented in https://github.com/UDST/urbansim_templates/pull/15, and will make diffs of the config files behave better.